### PR TITLE
Add Javadoc comments for Main and utility methods

### DIFF
--- a/src/main/java/blob/DialogBox.java
+++ b/src/main/java/blob/DialogBox.java
@@ -24,6 +24,14 @@ public class DialogBox extends HBox {
     @FXML
     private ImageView displayPicture;
 
+    /**
+     * Constructs a DialogBox with the specified text and image.
+     * Loads the DialogBox layout from an FXML file and initializes
+     * the dialog text and display image.
+     *
+     * @param text The text content of the dialog.
+     * @param img  The image associated with the dialog.
+     */
     private DialogBox(String text, Image img) {
         try {
             FXMLLoader fxmlLoader = new FXMLLoader(MainWindow.class.getResource("/view/DialogBox.fxml"));
@@ -48,10 +56,25 @@ public class DialogBox extends HBox {
         setAlignment(Pos.TOP_LEFT);
     }
 
+    /**
+     * Creates a DialogBox representing the user's message.
+     *
+     * @param text The text content of the user's message.
+     * @param img  The image representing the user.
+     * @return A DialogBox containing the user's message and image.
+     */
     public static DialogBox getUserDialog(String text, Image img) {
         return new DialogBox(text, img);
     }
 
+    /**
+     * Creates a DialogBox representing Blob's response.
+     * The dialog box is flipped to differentiate it from the user's message.
+     *
+     * @param text The text content of Blob's response.
+     * @param img  The image representing Blob.
+     * @return A flipped DialogBox containing Blob's response and image.
+     */
     public static DialogBox getBlobDialog(String text, Image img) {
         var db = new DialogBox(text, img);
         db.flip();

--- a/src/main/java/blob/Launcher.java
+++ b/src/main/java/blob/Launcher.java
@@ -6,6 +6,13 @@ import javafx.application.Application;
  * A launcher class to workaround classpath issues.
  */
 public class Launcher {
+    /**
+     * The entry point for launching the JavaFX application.
+     * This method initiates the JavaFX application by calling the
+     * launch method on the Main class, passing the command-line arguments.
+     *
+     * @param args Command-line arguments passed to the application.
+     */
     public static void main(String[] args) {
         Application.launch(Main.class, args);
     }

--- a/src/main/java/blob/Main.java
+++ b/src/main/java/blob/Main.java
@@ -15,6 +15,15 @@ public class Main extends Application {
 
     private final Blob blob = new Blob();
 
+    /**
+     * Initializes and shows the main GUI window for the Blob application.
+     * This method loads the FXML layout for the main window, sets up the
+     * scene and stage for the JavaFX application, and injects the Blob instance
+     * into the controller. It also handles any IOExceptions that may occur
+     * during the loading of the FXML file.
+     *
+     * @param stage The primary stage for the JavaFX application.
+     */
     @Override
     public void start(Stage stage) {
         try {


### PR DESCRIPTION
*  Added Javadoc comments to the getUserDialog and getBlobDialog methods in the DialogBox class to provide a clearer explanation of their functionality.
*  Documented the start method in the Main class to explain its role in initializing and displaying the main GUI window. 
These additions improve code readability and maintainability, providing developers with a clear understanding of the methods' purposes and usage.